### PR TITLE
feat(proxmox): increase VM disk sizes

### DIFF
--- a/proxmox/terraform/controlplane.tf
+++ b/proxmox/terraform/controlplane.tf
@@ -11,4 +11,5 @@ module "phoenix" {
   gateway     = var.gateway
   dns         = var.dns
   hostname    = "phoenix"
+  disk_size   = 150
 }

--- a/proxmox/terraform/modules/proxmox-vm/main.tf
+++ b/proxmox/terraform/modules/proxmox-vm/main.tf
@@ -32,6 +32,12 @@ resource "proxmox_virtual_environment_vm" "vm" {
     enabled = true
   }
 
+  disk {
+    datastore_id = var.disk_datastore_id
+    interface    = "scsi0"
+    size         = var.disk_size
+  }
+
   network_device {
     bridge      = "vmbr0"
     mac_address = var.mac_address

--- a/proxmox/terraform/modules/proxmox-vm/variables.tf
+++ b/proxmox/terraform/modules/proxmox-vm/variables.tf
@@ -81,3 +81,15 @@ variable "hostname" {
   type        = string
   default     = ""
 }
+
+variable "disk_size" {
+  description = "Disk size in GB"
+  type        = number
+  default     = 100
+}
+
+variable "disk_datastore_id" {
+  description = "Proxmox datastore ID for the VM disk"
+  type        = string
+  default     = "local-lvm"
+}

--- a/proxmox/terraform/nodes.tf
+++ b/proxmox/terraform/nodes.tf
@@ -2,30 +2,32 @@
 module "yamato" {
   source = "./modules/proxmox-vm"
 
-  vm_name              = "yamato"
-  vm_id                = 101
-  cores                = 2
-  memory               = 4096
-  mac_address          = "BC:24:11:21:00:01"
-  static_ip            = var.vm_ips[1]
-  gateway              = var.gateway
-  dns                  = var.dns
-  hostname             = "yamato"
-  depends_on_resource  = module.phoenix.network_config_id
+  vm_name             = "yamato"
+  vm_id               = 101
+  cores               = 2
+  memory              = 4096
+  mac_address         = "BC:24:11:21:00:01"
+  static_ip           = var.vm_ips[1]
+  gateway             = var.gateway
+  dns                 = var.dns
+  hostname            = "yamato"
+  disk_size           = 100
+  depends_on_resource = module.phoenix.network_config_id
 }
 
 # Defcom - Worker (4GB RAM, 2 cores)
 module "defcom" {
   source = "./modules/proxmox-vm"
 
-  vm_name              = "defcom"
-  vm_id                = 102
-  cores                = 2
-  memory               = 4096
-  mac_address          = "BC:24:11:22:00:01"
-  static_ip            = var.vm_ips[2]
-  gateway              = var.gateway
-  dns                  = var.dns
-  hostname             = "defcom"
-  depends_on_resource  = module.yamato.network_config_id
+  vm_name             = "defcom"
+  vm_id               = 102
+  cores               = 2
+  memory              = 4096
+  mac_address         = "BC:24:11:22:00:01"
+  static_ip           = var.vm_ips[2]
+  gateway             = var.gateway
+  dns                 = var.dns
+  hostname            = "defcom"
+  disk_size           = 100
+  depends_on_resource = module.yamato.network_config_id
 }


### PR DESCRIPTION
## Summary

- Add explicit `disk` block to the `proxmox-vm` Terraform module with configurable `disk_size` and `disk_datastore_id` variables
- Set **phoenix** (control plane) to **150 GB** and **yamato/defcom** (workers) to **100 GB**
- Previously disks were not managed by Terraform — they inherited the 20 GB Packer template size

## Test plan

- [x] `terraform validate` — passes locally
- [x] `terraform apply --auto-approve` — successfully applied to all 3 VMs in Proxmox
- [ ] SSH into each node and verify `df -h /` shows expected free space

🤖 Generated with [Claude Code](https://claude.com/claude-code)