### PR TITLE
feat(argocd): add node anti-affinity and control-plane toleration

### DIFF
--- a/ansible/roles/argocd/tasks/files/argocd-values.yaml
+++ b/ansible/roles/argocd/tasks/files/argocd-values.yaml
@@ -1,3 +1,15 @@
+## Global
+global:
+  # Allow scheduling on control-plane node (phoenix)
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+
+  # Prefer spreading ArgoCD components across different nodes
+  affinity:
+    podAntiAffinity: soft
+
 ## Server
 server:
   # -- Argo CD server name


### PR DESCRIPTION
## Summary

- Add `global.tolerations` to allow ArgoCD pods to schedule on the phoenix control-plane node (`node-role.kubernetes.io/control-plane:NoSchedule`)
- Add `global.affinity.podAntiAffinity: soft` to spread ArgoCD components across nodes using `preferredDuringSchedulingIgnoredDuringExecution`
- Revert `targetRevision` back to `HEAD` (was temporarily set to feature branch for testing)

## Result

Before: all 7 ArgoCD pods on `defcom` only.
After: pods distributed across all 3 nodes (phoenix, yamato, defcom).

## Test plan

- [x] Branch pushed and ArgoCD Application pointed to it
- [x] Hard refresh triggered — no ComparisonError
- [x] `argocd app sync argocd --prune` — Healthy + Synced
- [x] `kubectl get pods -n argocd -o wide` — pods spread across phoenix, yamato, defcom

🤖 Generated with [Claude Code](https://claude.com/claude-code)